### PR TITLE
Set active tab using key of first tab

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,12 @@
 Change Log: `yii2-tabs-x`
 =========================
 
+## Version 1.2.5
+
+**Date:** 24-August-2017
+
+- (bug #51): Add missing `hashVarLoadPosition` property.
+
 ## Version 1.2.4
 
 **Date:** 04-May-2017

--- a/CHANGE.md
+++ b/CHANGE.md
@@ -5,7 +5,7 @@ Change Log: `yii2-tabs-x`
 
 **Date:** 24-August-2017
 
-- (bug #51): Add missing `hashVarLoadPosition` property.
+- (bug #51): Fix setting active tab with named tab definition.
 
 ## Version 1.2.4
 

--- a/TabsX.php
+++ b/TabsX.php
@@ -309,7 +309,8 @@ class TabsX extends Tabs
         $headers = $panes = $labels = [];
 
         if (!$this->hasActiveTab() && !empty($this->items)) {
-            $this->items[0]['active'] = true;
+        	reset($this->items);
+            $this->items[key($this->items)]['active'] = true;
         }
 
         foreach ($this->items as $n => $item) {


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix

## Changes

- Set active tab using keyname of first tab