### PR TITLE
Fix for #54

### DIFF
--- a/TabsX.php
+++ b/TabsX.php
@@ -367,7 +367,10 @@ class TabsX extends Tabs
         }
         $outHeader = Html::tag('ul', implode("\n", $headers), $this->options);
         if ($this->renderTabContent) {
-            $outPane = Html::beginTag('div', ['class' => 'tab-content' . $this->getCss('printable', $this->printable)]);
+            if ($this->printable) {
+                Html::addCssClass($this->tabContentOptions, 'printable');
+            }
+            $outPane = Html::beginTag('div', $this->tabContentOptions);
             foreach ($panes as $i => $pane) {
                 if ($this->printable) {
                     $outPane .= Html::tag('div', ArrayHelper::getValue($labels, $i), $this->printHeaderOptions) . "\n";


### PR DESCRIPTION
Fixed issue #54 - tabContentOptions setting ignored

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-tabs-x/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.