### PR TITLE
TabsXAssets registers non existent css asset

### DIFF
--- a/src/TabsXAsset.php
+++ b/src/TabsXAsset.php
@@ -23,7 +23,6 @@ class TabsXAsset extends PluginAssetBundle
     public function init()
     {
         $this->setSourcePath('@vendor/kartik-v/bootstrap-tabs-x');
-        $this->setupAssets('css', ['css/bootstrap-tabs-x' . ($this->isBs4() ? '-bs4' : '')]);
         $this->setupAssets('js', ['js/bootstrap-tabs-x']);
         parent::init();
     }


### PR DESCRIPTION
I think line 26 is obsolete as there is no css file that the assetBundle tries to register.

## Scope
This pull request includes a

- [ x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-tabs-x/blob/master/CHANGE.md)):

Nonexistent css file removed from AssetBundle
